### PR TITLE
remove toHex

### DIFF
--- a/core/cli.py
+++ b/core/cli.py
@@ -74,4 +74,4 @@ def do_resolution(hash, gas_price):
     tx = send_or_transact(args)
     rct = g.w3.eth.waitForTransactionReceipt(tx)
 
-    click.echo(C.RESOLVED % g.w3.toHex(hash))
+    click.echo(C.RESOLVED % hash)

--- a/tests/cli/test_resolution.py
+++ b/tests/cli/test_resolution.py
@@ -40,7 +40,9 @@ def test_resolve(w3, voting, parameterizer_opts, datatrust, ctx):
 
     # now resolve it
     runner = current_app.test_cli_runner()
-    result = runner.invoke(args=['admin', 'resolution_test', '--hash', reg_hash])
+
+    #pass a string like cli does
+    result = runner.invoke(args=['admin', 'resolution_test', '--hash', w3.toHex(reg_hash)])
     assert (RESOLVED % w3.toHex(reg_hash)) in result.output
 
 def test_was_actually_resolved(w3, voting, ctx):


### PR DESCRIPTION
was causing an error when being called on a string, which is what the actual CLI passes.